### PR TITLE
Update amber formula to target the latest release

### DIFF
--- a/Formula/amber-bash.rb
+++ b/Formula/amber-bash.rb
@@ -29,7 +29,6 @@ class AmberBash < Formula
   end
 
   def cleanup
-
     # Prevent the caveats message from being printed again
     odisabled "caveats"
   end

--- a/Formula/amber-bash.rb
+++ b/Formula/amber-bash.rb
@@ -27,4 +27,10 @@ class AmberBash < Formula
 
     assert_equal "Hello, World", shell_output("#{bin}/amber main.ab").strip
   end
+
+  def cleanup
+
+    # Prevent the caveats message from being printed again
+    odisabled "caveats"
+  end
 end

--- a/Formula/amber-bash.rb
+++ b/Formula/amber-bash.rb
@@ -1,8 +1,8 @@
-class AmberLang < Formula
+class AmberBash < Formula
   desc "Amber, the programming language that compiles to Bash"
   homepage "https://amber-lang.com"
-  url "https://github.com/Ph0enixKM/Amber/releases/download/0.3.3-alpha/source.tar.gz"
-  sha256 "54a4f681f8ea1b19543ffa1569203c3bff88ef8ffe73422424f65f8be3cf5cd0"
+  url "https://github.com/Ph0enixKM/Amber/releases/download/0.3.4-alpha/source.tar.gz"
+  sha256 "26da447d26b1c502b87055fdaae3a62f443e4f0d1c8866e6dca995ee664cc3b4"
   license "GPL-3.0-only"
 
   depends_on "rust" => :build
@@ -13,9 +13,9 @@ class AmberLang < Formula
 
   def caveats
     <<~EOS
-      Amber programs need Bash to run. macOS and most Linux distributions ship with it preinstalled, but some (Alpine, for instance) do not.
+      Programs written in amber require Bash to run. macOS and most Linux distributions ship with bash preinstalled, but some (Alpine, for instance) do not.
 
-      In order to run built programs, please make sure you have Bash installed.
+      In order to run built programs, please make sure you have Bash already installed.
     EOS
   end
 


### PR DESCRIPTION
## **PR Description**

### **Changes Made:**

* Updated amber-lang formula to version 0.3.4-alpha.
* Renamed formula from amber-lang to amber-bash to comply with package naming guidelines.
* Added `odisabled "caveats"` in the formula's cleanup step to prevent duplicate caveat printing.
* Improved clarity of caveat text.

### **Acceptance Criteria:**

1. Formula successfully downloads amber's 0.3.4-alpha source code.
2. Amber compiles without errors.
3. Amber installs properly and can be executed from the console.

### **Test Plans:**

1. Installed amber through the updated formula from a forked downstream homebrew tap.
2. Verified formula build and installation without errors.
3. Tested amber to ensure functionality.
4. Checked amber version to confirm installation of the latest release.